### PR TITLE
Add sign up cancellation and position management

### DIFF
--- a/queues/models.py
+++ b/queues/models.py
@@ -34,7 +34,7 @@ class Queue:
         if pos is None:
             pos = 1 if not self.id_to_pos else max(self.id_to_pos.values()) + 1
             if pos > MAX_QUEUE_SIZE:
-                return 'Похоже, кто-то уже занял самое последнее место.'
+                return 'Похоже, кто-то уже занял самое последнее место'
         if pos <= 0 or pos > MAX_QUEUE_SIZE:
             return 'не-не-не'
         if self.queue[pos - 1] == self.EMPTY:
@@ -42,7 +42,7 @@ class Queue:
             self.id_to_pos[user_id] = pos
             return None
         else:
-            return 'Это место уже занято.'
+            return 'Это место уже занято'
             
     def remove(self, user_id):
         self.queue[self.id_to_pos[user_id] - 1] = self.EMPTY
@@ -87,7 +87,7 @@ class QueueModel:
             if ret is None:
                 self.update_queue(queue_object)
             return ret
-        return 'Ты уже есть в очереди.'
+        return 'Ты уже есть в очереди'
         
     def cancel_sign_up(self, date, subject, user_id):
         if (date, subject) not in queue_model.queues:
@@ -97,7 +97,7 @@ class QueueModel:
             queue_object.remove(user_id)
             self.update_queue(queue_object)
             return None
-        return 'Тебя и так нет в этой очереди.'
+        return 'Тебя и так нет в этой очереди'
         
     def move(self, date, subject, user_id, new_pos):
         if (date, subject) not in queue_model.queues:
@@ -110,7 +110,7 @@ class QueueModel:
                 queue_object.queue[old_pos - 1] = queue_object.EMPTY
                 self.update_queue(queue_object)
             return ret
-        return 'Тебя нет в этой очереди. Используй /sign_up.'
+        return 'Тебя нет в этой очереди. Используй /sign_up'
 
     def clear_queue(self, date, subject):
         if (date, subject) in self.queues:

--- a/queues/models.py
+++ b/queues/models.py
@@ -26,20 +26,20 @@ class Queue:
         
     def add_to_pos(self, user_id, pos):
         if pos is None:
-            pos = max(self.id_to_pos.values()) + 1
+            pos = 1 if not self.id_to_pos else max(self.id_to_pos.values()) + 1
             if pos > MAX_QUEUE_SIZE:
                 return 'Похоже, кто-то уже занял самое последнее место.'
         if pos <= 0 or pos > MAX_QUEUE_SIZE:
             return 'не-не-не'
-        if self.queue[pos] == self.EMPTY:
-            self.queue[pos] = user_id
+        if self.queue[pos - 1] == self.EMPTY:
+            self.queue[pos - 1] = user_id
             self.id_to_pos[user_id] = pos
             return None
         else:
             return 'Это место уже занято.'
             
     def remove(self, user_id):
-        self.queue[self.id_to_pos[user_id]] = self.EMPTY
+        self.queue[self.id_to_pos[user_id] - 1] = self.EMPTY
         self.id_to_pos.pop(user_id)
     
 

--- a/queues/models.py
+++ b/queues/models.py
@@ -16,7 +16,7 @@ class Queue:
         self.id_to_pos = {}
 
     def __str__(self):
-        if self.queue:
+        if self.id_to_pos:
             return f'{self.date}, {self.subject}\nОчередь:\n' +\
                    '\n'.join([f'{i + 1}. {user_model.users[user_id].first_name} '
                               f'{user_model.users[user_id].last_name}'

--- a/queues/models.py
+++ b/queues/models.py
@@ -104,8 +104,8 @@ class QueueModel:
             return 'Очередь для заданных предмета и даты не найдена :('
         queue_object = self.queues[(date, subject)]
         if user_id in user_model.users and user_id in queue_object.id_to_pos:
-            old_pos = queue_object.id_to_pos.user_id
-            ret = queue_object.add_to_pos(user_id, pos)
+            old_pos = queue_object.id_to_pos[user_id]
+            ret = queue_object.add_to_pos(user_id, new_pos)
             if ret is None:
                 queue_object.queue[old_pos - 1] = queue_object.EMPTY
                 self.update_queue(queue_object)

--- a/queues/models.py
+++ b/queues/models.py
@@ -2,52 +2,39 @@ import pickle
 from base.decorators.db import connector
 from users.models import user_model
 
-
-MAX_QUEUE_SIZE = len(user_model.users) + 20
+MAX_QUEUE_SIZE = 30
 
 
 class Queue:
     EMPTY = ''
-    
-    def __init__(self, subject, date, queue=None):
+
+    def __init__(self, subject, positions=None):
         self.subject = subject
-        self.date = date
-        if queue is None:
-            self.queue = [self.EMPTY] * MAX_QUEUE_SIZE
-            self.id_to_pos = {}
-        else:
-            self.queue = queue
-            self.id_to_pos = {user_id: i + 1
-                              for i, user_id in enumerate(queue)
-                              if user_id != self.EMPTY}
+        self.positions = positions or {}
 
     def __str__(self):
-        if self.id_to_pos:
-            return f'{self.date}, {self.subject}\nОчередь:\n' +\
-                   '\n'.join([f'{i + 1}. {user_model.users[user_id].first_name} '
+        if self.positions:
+            return f'{self.subject}\nОчередь:\n' + \
+                   '\n'.join([f'{i}. {user_model.users[user_id].first_name} '
                               f'{user_model.users[user_id].last_name}'
-                              for i, user_id in enumerate(self.queue)
-                              if user_id != self.EMPTY])
-        return f'{self.date}, {self.subject}. Очередь пока пустая, занимай пока не поздно'
-        
+                              for user_id, i in sorted(list(self.positions.items()),
+                                                       key=lambda x: x[1])])
+        return f'{self.subject}. Очередь пока пустая, занимай пока не поздно'
+
     def add_to_pos(self, user_id, pos):
         if pos is None:
-            pos = 1 if not self.id_to_pos else max(self.id_to_pos.values()) + 1
+            pos = 1 if not self.positions else max(self.positions.values()) + 1
             if pos > MAX_QUEUE_SIZE:
                 return 'Похоже, кто-то уже занял самое последнее место'
         if pos <= 0 or pos > MAX_QUEUE_SIZE:
             return 'не-не-не'
-        if self.queue[pos - 1] == self.EMPTY:
-            self.queue[pos - 1] = user_id
-            self.id_to_pos[user_id] = pos
+        if pos not in self.positions.values():
+            self.positions[user_id] = pos
             return None
-        else:
-            return 'Это место уже занято'
-            
+        return 'Это место уже занято'
+
     def remove(self, user_id):
-        self.queue[self.id_to_pos[user_id] - 1] = self.EMPTY
-        self.id_to_pos.pop(user_id)
-    
+        self.positions.pop(user_id)
 
 
 class QueueModel:
@@ -63,59 +50,57 @@ class QueueModel:
         data = self.cursor.fetchall()
         if data:
             for queue in data:
-                self.queues[(queue[2], queue[1])] = Queue(*queue[1:3], pickle.loads(queue[3]))
+                self.queues[queue[1]] = Queue(subject=queue[1],
+                                              positions=pickle.loads(queue[2]))
 
     @connector
     def add_queue(self, queue: Queue):
-        self.cursor.execute("""INSERT INTO queues VALUE (%s, %s, %s, %s)""", (None,
-                                                                              queue.subject,
-                                                                              queue.date,
-                                                                              pickle.dumps(queue.queue)))
-        self.queues[(queue.date, queue.subject)] = queue
+        self.cursor.execute("""INSERT INTO queues VALUE (%s, %s, %s)""", (None,
+                                                                          queue.subject,
+                                                                          pickle.dumps(queue.positions)))
+        self.queues[queue.subject] = queue
 
     @connector
     def update_queue(self, queue: Queue):
-        self.cursor.execute("""UPDATE queues SET queue=(%s) WHERE subject=(%s) and date=(%s)""",
-                            (pickle.dumps(queue.queue), queue.subject, queue.date))
+        self.cursor.execute("""UPDATE queues SET positions=(%s) WHERE subject=(%s)""",
+                            (pickle.dumps(queue.positions), queue.subject))
 
-    def sign_up(self, date, subject, user_id, pos=None):
-        if (date, subject) not in queue_model.queues:
-            return 'Очередь для заданных предмета и даты не найдена :('
-        queue_object = self.queues[(date, subject)]
-        if user_id in user_model.users and user_id not in queue_object.queue:
-            ret = queue_object.add_to_pos(user_id, pos)
-            if ret is None:
+    def sign_up(self, subject, user_id, pos=None):
+        if subject not in queue_model.queues:
+            return 'Очередь для заданного предмета не найдена :('
+        queue_object = self.queues[subject]
+        if user_id in user_model.users and user_id not in queue_object.positions:
+            result = queue_object.add_to_pos(user_id, pos)
+            if result is None:
                 self.update_queue(queue_object)
-            return ret
+            return result
         return 'Ты уже есть в очереди'
-        
-    def cancel_sign_up(self, date, subject, user_id):
-        if (date, subject) not in queue_model.queues:
-            return 'Очередь для заданных предмета и даты не найдена :('
-        queue_object = self.queues[(date, subject)]
-        if user_id in user_model.users and user_id in queue_object.id_to_pos:
+
+    def cancel_sign_up(self, subject, user_id):
+        if subject not in queue_model.queues:
+            return 'Очередь для заданного предмета не найдена :('
+        queue_object = self.queues[subject]
+        if user_id in user_model.users and user_id in queue_object.positions:
             queue_object.remove(user_id)
             self.update_queue(queue_object)
             return None
         return 'Тебя и так нет в этой очереди'
-        
-    def move(self, date, subject, user_id, new_pos):
-        if (date, subject) not in queue_model.queues:
-            return 'Очередь для заданных предмета и даты не найдена :('
-        queue_object = self.queues[(date, subject)]
-        if user_id in user_model.users and user_id in queue_object.id_to_pos:
-            old_pos = queue_object.id_to_pos[user_id]
-            ret = queue_object.add_to_pos(user_id, new_pos)
-            if ret is None:
-                queue_object.queue[old_pos - 1] = queue_object.EMPTY
+
+    def move(self, subject, user_id, new_pos):
+        if subject not in queue_model.queues:
+            return 'Очередь для заданного предмета не найдена :('
+        queue_object = self.queues[subject]
+        if user_id in user_model.users and user_id in queue_object.positions:
+            result = queue_object.add_to_pos(user_id, new_pos)
+            if result is None:
                 self.update_queue(queue_object)
-            return ret
+            return result
         return 'Тебя нет в этой очереди. Используй /sign_up'
 
-    def clear_queue(self, date, subject):
-        if (date, subject) in self.queues:
-            self.queues[(date, subject)].queue = []
-            self.update_queue(self.queues[(date, subject)])
+    def clear_queue(self, subject):
+        if subject in self.queues:
+            self.queues[subject].positions.clear()
+            self.update_queue(self.queues[subject])
             return True
         return False
 

--- a/queues/models.py
+++ b/queues/models.py
@@ -12,8 +12,14 @@ class Queue:
     def __init__(self, subject, date, queue=None):
         self.subject = subject
         self.date = date
-        self.queue = queue or [self.EMPTY] * MAX_QUEUE_SIZE
-        self.id_to_pos = {}
+        if queue is None:
+            self.queue = [self.EMPTY] * MAX_QUEUE_SIZE
+            self.id_to_pos = {}
+        else:
+            self.queue = queue
+            self.id_to_pos = {user_id: i + 1
+                              for i, user_id in enumerate(queue)
+                              if user_id != self.EMPTY}
 
     def __str__(self):
         if self.id_to_pos:
@@ -94,10 +100,17 @@ class QueueModel:
         return 'Тебя и так нет в этой очереди.'
         
     def move(self, date, subject, user_id, new_pos):
-        ret = self.cancel_sign_up(date, subject, user_id)
-        if ret is not None:
+        if (date, subject) not in queue_model.queues:
+            return 'Очередь для заданных предмета и даты не найдена :('
+        queue_object = self.queues[(date, subject)]
+        if user_id in user_model.users and user_id in queue_object.id_to_pos:
+            old_pos = queue_object.id_to_pos.user_id
+            ret = queue_object.add_to_pos(user_id, pos)
+            if ret is None:
+                queue_object.queue[old_pos - 1] = queue_object.EMPTY
+                self.update_queue(queue_object)
             return ret
-        return self.sign_up(date, subject, user_id, new_pos)
+        return 'Тебя нет в этой очереди. Используй /sign_up.'
 
     def clear_queue(self, date, subject):
         if (date, subject) in self.queues:

--- a/queues/views.py
+++ b/queues/views.py
@@ -17,9 +17,9 @@ def sign_up(message):
             raise ValueError()
             
         user_id = message.from_user.id
-        if command == 'sign_up':
+        if command == '/sign_up':
             ret = queue_model.sign_up(date, subject, user_id, pos)
-        elif command == 'move':
+        elif command == '/move':
             ret = queue_model.move(date, subject, user_id, pos)
         if ret is None:
             bot.send_message(message.chat.id, f'{user_model.users[user_id].first_name} '

--- a/queues/views.py
+++ b/queues/views.py
@@ -32,7 +32,7 @@ def sign_up(message):
         bot.send_message(message.chat.id, 'wrong format')
         
         
-@bot.message_handler(commands=['cancel_sign_up'])
+@bot.message_handler(commands=['cancel'])
 @exception_handler
 def cancel_sign_up(message):
     try:

--- a/queues/views.py
+++ b/queues/views.py
@@ -23,9 +23,10 @@ def sign_up(message):
         elif command == '/move':
             ret = queue_model.move(date, subject, user_id, pos)
         if ret is None:
+            resulting_pos = queue_model.queues[(date, subject)].id_to_pos[user_id]
             bot.send_message(message.chat.id, f'{user_model.users[user_id].first_name} '
                                               f'{user_model.users[user_id].last_name} теперь в очереди '
-                                              f'{date} на {subject}')
+                                              f'{date} на {subject} на позиции {resulting_pos}')
         else:
             bot.send_message(message.chat.id, ret)
     except ValueError:

--- a/queues/views.py
+++ b/queues/views.py
@@ -4,18 +4,46 @@ from queues.models import queue_model, Queue
 from users.models import user_model
 
 
-@bot.message_handler(commands=['sign_up'])
+@bot.message_handler(commands=['sign_up', 'move'])
 @exception_handler
 def sign_up(message):
     try:
-        command, date, subject = message.text.split(maxsplit=2)
+        args = message.text.split(maxsplit=3)
+        if len(args) == 4:
+            command, date, subject, pos = args
+        elif len(args) == 3:
+            command, date, subject, pos = *args, None
+        else:
+            raise ValueError()
+            
         user_id = message.from_user.id
-        if queue_model.sign_up(date, subject, user_id):
+        if command == 'sign_up':
+            ret = queue_model.sign_up(date, subject, user_id, pos)
+        elif command == 'move':
+            ret = queue_model.move(date, subject, user_id, pos)
+        if ret is None:
             bot.send_message(message.chat.id, f'{user_model.users[user_id].first_name} '
                                               f'{user_model.users[user_id].last_name} теперь в очереди '
                                               f'{date} на {subject}')
         else:
-            bot.send_message(message.chat.id, 'Очередь для заданных предмета и даты не найдена :(')
+            bot.send_message(message.chat.id, ret)
+    except ValueError:
+        bot.send_message(message.chat.id, 'wrong format')
+        
+        
+@bot.message_handler(commands=['cancel_sign_up'])
+@exception_handler
+def cancel_sign_up(message):
+    try:
+        command, date, subject = message.text.split(maxsplit=2)
+        user_id = message.from_user.id
+        ret = queue_model.cancel_sign_up(date, subject, user_id)
+        if ret is None:
+            bot.send_message(message.chat.id, f'{user_model.users[user_id].first_name} '
+                                              f'{user_model.users[user_id].last_name} теперь не в очереди '
+                                              f'{date} на {subject}')
+        else:
+            bot.send_message(message.chat.id, ret)
     except ValueError:
         bot.send_message(message.chat.id, 'wrong format')
 

--- a/queues/views.py
+++ b/queues/views.py
@@ -11,6 +11,7 @@ def sign_up(message):
         args = message.text.split(maxsplit=3)
         if len(args) == 4:
             command, date, subject, pos = args
+            pos = int(pos)
         elif len(args) == 3:
             command, date, subject, pos = *args, None
         else:

--- a/queues/views.py
+++ b/queues/views.py
@@ -8,27 +8,27 @@ from users.models import user_model
 @exception_handler
 def sign_up(message):
     try:
-        args = message.text.split(maxsplit=3)
-        if len(args) == 4:
-            command, date, subject, pos = args
+        args = message.text.split(maxsplit=2)
+        if len(args) == 3:
+            command, subject, pos = args
             pos = int(pos)
-        elif len(args) == 3:
-            command, date, subject, pos = *args, None
+        elif len(args) == 2:
+            command, subject, pos = *args, None
         else:
             raise ValueError()
-            
+
         user_id = message.from_user.id
         if command == '/sign_up':
-            ret = queue_model.sign_up(date, subject, user_id, pos)
-        elif command == '/move':
-            ret = queue_model.move(date, subject, user_id, pos)
-        if ret is None:
-            resulting_pos = queue_model.queues[(date, subject)].id_to_pos[user_id]
+            result = queue_model.sign_up(subject, user_id, pos)
+        else:
+            result = queue_model.move(subject, user_id, pos)
+        if result is None:
+            resulting_pos = queue_model.queues[subject].positions[user_id]
             bot.send_message(message.chat.id, f'{user_model.users[user_id].first_name} '
                                               f'{user_model.users[user_id].last_name} теперь в очереди '
-                                              f'{date} на {subject} на позиции {resulting_pos}')
+                                              f'на {subject}, позиция: {resulting_pos}')
         else:
-            bot.send_message(message.chat.id, ret)
+            bot.send_message(message.chat.id, result)
     except ValueError:
         bot.send_message(message.chat.id, 'wrong format')
         
@@ -37,15 +37,15 @@ def sign_up(message):
 @exception_handler
 def cancel_sign_up(message):
     try:
-        command, date, subject = message.text.split(maxsplit=2)
+        command, subject = message.text.split(maxsplit=1)
         user_id = message.from_user.id
-        ret = queue_model.cancel_sign_up(date, subject, user_id)
-        if ret is None:
+        result = queue_model.cancel_sign_up(subject, user_id)
+        if result is None:
             bot.send_message(message.chat.id, f'{user_model.users[user_id].first_name} '
                                               f'{user_model.users[user_id].last_name} теперь не в очереди '
-                                              f'{date} на {subject}')
+                                              f'на {subject}')
         else:
-            bot.send_message(message.chat.id, ret)
+            bot.send_message(message.chat.id, result)
     except ValueError:
         bot.send_message(message.chat.id, 'wrong format')
 
@@ -54,11 +54,11 @@ def cancel_sign_up(message):
 @exception_handler
 def send_queue(message):
     try:
-        command, date, subject = message.text.split(maxsplit=2)
-        if (date, subject) in queue_model.queues:
-            bot.send_message(message.chat.id, str(queue_model.queues[(date, subject)]))
+        command, subject = message.text.split(maxsplit=1)
+        if subject in queue_model.queues:
+            bot.send_message(message.chat.id, str(queue_model.queues[subject]))
         else:
-            bot.send_message(message.chat.id, 'Очередь для заданных предмета и даты не найдена :(')
+            bot.send_message(message.chat.id, 'Очередь для заданного предмета не найдена :(')
     except ValueError:
         bot.send_message(message.chat.id, 'wrong format')
 
@@ -68,8 +68,8 @@ def send_queue(message):
 @admin_only
 def add_queue(message):
     try:
-        command, date, subject = message.text.split(maxsplit=2)
-        queue_model.add_queue(Queue(date=date, subject=subject))
+        command, subject = message.text.split(maxsplit=1)
+        queue_model.add_queue(Queue(subject))
         bot.send_message(message.chat.id, 'Очередь создана')
     except ValueError:
         bot.send_message(message.chat.id, 'wrong format')
@@ -80,8 +80,8 @@ def add_queue(message):
 @admin_only
 def clear_queue(message):
     try:
-        command, date, subject = message.text.split(maxsplit=3)
-        if queue_model.clear_queue(date, subject):
+        command, subject = message.text.split(maxsplit=1)
+        if queue_model.clear_queue(subject):
             bot.send_message(message.chat.id, 'Очередь очищена')
     except ValueError:
         bot.send_message(message.chat.id, 'wrong format')


### PR DESCRIPTION
Теперь можно делать:
* `/sign_up subject date pos`, чтобы записаться на конкретное место
* `/sign_up subject date`, чтобы записаться в конец
* `/move subject date pos`, если ты уже в очереди, но хочешь переместиться на другое пустое место
* `/cancel subject date`, если ты передумал 

В плане менеджмента позиций можно конечно еще добавлять всякие свапы и рандомизации очередей, но вообще-то для этого другой бот есть, ну и это короче как нибудь потом