### PR TITLE
Add last queue mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+config.py

--- a/queues/models.py
+++ b/queues/models.py
@@ -1,25 +1,25 @@
 import pickle
 from base.decorators.db import connector
+from queues import status
 from users.models import user_model
 
 MAX_QUEUE_SIZE = 30
 
 
 class Queue:
-    EMPTY = ''
-
-    def __init__(self, subject, positions=None):
-        self.subject = subject
+    def __init__(self, name, positions=None):
+        self.name = name
         self.positions = positions or {}
 
     def __str__(self):
         if self.positions:
-            return f'{self.subject}\nОчередь:\n' + \
+            sorted_queue = sorted(list(self.positions.items()),
+                                  key=lambda x: x[1])
+            return f'{self.name}\nОчередь:\n' + \
                    '\n'.join([f'{i}. {user_model.users[user_id].first_name} '
                               f'{user_model.users[user_id].last_name}'
-                              for user_id, i in sorted(list(self.positions.items()),
-                                                       key=lambda x: x[1])])
-        return f'{self.subject}. Очередь пока пустая, занимай пока не поздно'
+                              for user_id, i in sorted_queue])
+        return f'{self.name}. Очередь пока пустая, занимай пока не поздно'
 
     def add_to_pos(self, user_id, pos):
         if pos is None:
@@ -43,94 +43,117 @@ class QueueModel:
         self.conn = None
         self.last_queue = None
         self.queues = dict()
-        self.__read_database()
+        self._read_database()
 
     @connector
-    def __read_database(self):
+    def _read_database(self):
         self.cursor.execute("""SELECT * FROM queues""")
         data = self.cursor.fetchall()
         if data:
-            for queue in data:
-                self.queues[queue[1]] = Queue(subject=queue[1],
-                                              positions=pickle.loads(queue[2]))
-                if queue[3] == 1:
-                    self.last_queue = queue[1]
+            for _, name, queue_str, is_last in data:
+                self.queues[name] = Queue(name=name,
+                                          positions=pickle.loads(queue_str))
+                if is_last == 1:
+                    self.last_queue = name
+                    
+    @connector
+    def _update_last_queue(self, name):
+        if self.last_queue == name:
+            return
+        old_last_queue = self.last_queue
+        self.last_queue = name
+        self.cursor.execute("""UPDATE queues SET is_last=1 WHERE subject=(%s)""",
+                            (name,))
+        if old_last_queue is not None:
+            self.cursor.execute("""UPDATE queues SET is_last=0 WHERE subject=(%s)""",
+                                (old_last_queue,))
 
     @connector
     def add_queue(self, queue: Queue):
-        self.cursor.execute("""INSERT INTO queues VALUE (%s, %s, %s, %s)""", (None,
-                                                                          queue.subject,
-                                                                          pickle.dumps(queue.positions), 1))
-        self.queues[queue.subject] = queue
-        self.update_queue(queue)
+        if queue.name in self.queues:
+    	    status.handler.error('Очередь с таким именем уже существует')
+    	    return
+        self.cursor.execute("""INSERT INTO queues VALUE (%s, %s, %s, %s)""",
+                            (None, queue.name, pickle.dumps(queue.positions), 1))
+        self.queues[queue.name] = queue
+        self._update_last_queue(queue.name)
+        
+    @connector
+    def remove_queue(self, name):
+        queue = self._get_queue(name)
+        if queue is None:
+            return None
+        self.queues.pop(name)
+        self.cursor.execute("""DELETE FROM queues WHERE subject=(%s)""", (name,))
+        if self.last_queue == name:
+            self.last_queue = None
 
     @connector
-    def update_queue(self, queue: Queue):
-        old_last_queue = self.last_queue
-        self.last_queue = queue.subject
+    def _update_queue(self, queue: Queue):
         self.cursor.execute("""UPDATE queues SET positions=(%s) WHERE subject=(%s)""",
-                            (pickle.dumps(queue.positions), queue.subject))
-        self.cursor.execute("""UPDATE queues SET is_last=1 WHERE subject=(%s)""", (queue.subject,))
-        if old_last_queue is not None and old_last_queue != queue.subject:
-            self.cursor.execute("""UPDATE queues SET is_last=0 WHERE subject=(%s)""", (old_last_queue,))
+                            (pickle.dumps(queue.positions), queue.name))
+        self._update_last_queue(queue.name)
 
-    def sign_up(self, subject, user_id, pos=None):
-        if subject is None:
-            subject = self.last_queue
-        if subject not in queue_model.queues:
-            return 'Очередь для заданного предмета не найдена :('
-        queue_object = self.queues[subject]
-        if user_id in user_model.users and user_id not in queue_object.positions:
-            result = queue_object.add_to_pos(user_id, pos)
+    def sign_up(self, name, user_id, pos):
+        queue = self._get_queue(name)
+        if queue is None:
+            return None, None
+        elif user_id in queue.positions:
+            status.handler.error('Ты уже есть в очереди')
+        elif user_id in user_model.users:
+            result = queue.add_to_pos(user_id, pos)
             if result is None:
-                self.update_queue(queue_object)
-            return result
-        return 'Ты уже есть в очереди'
+                self._update_queue(queue)
+                return queue.name, queue.positions[user_id]
+        return None, None
 
-    def cancel_sign_up(self, subject, user_id):
-        if subject is None:
-            subject = self.last_queue
-        if subject not in queue_model.queues:
-            return 'Очередь для заданного предмета не найдена :('
-        queue_object = self.queues[subject]
-        if user_id in user_model.users and user_id in queue_object.positions:
-            queue_object.remove(user_id)
-            self.update_queue(queue_object)
+    def cancel_sign_up(self, name, user_id):
+        queue = self._get_queue(name)
+        if queue is None:
             return None
-        return 'Тебя и так нет в этой очереди'
-
-    def move(self, subject, user_id, new_pos):
-        if subject is None:
-            subject = self.last_queue
-        if subject not in queue_model.queues:
-            return 'Очередь для заданного предмета не найдена :('
-        queue_object = self.queues[subject]
-        if user_id in user_model.users and user_id in queue_object.positions:
-            result = queue_object.add_to_pos(user_id, new_pos)
-            if result is None:
-                self.update_queue(queue_object)
-            return result
-        return 'Тебя нет в этой очереди. Используй /sign_up'
-
-    def clear_queue(self, subject):
-        if subject is None:
-            subject = self.last_queue
-        if subject in self.queues:
-            self.queues[subject].positions.clear()
-            self.update_queue(self.queues[subject])
-            return True
-        return False
+        elif user_id not in queue.positions:
+            status.handler.error('Тебя и так нет в этой очереди')
+        elif user_id in user_model.users:
+            queue.remove(user_id)
+            self._update_queue(queue)
+            return queue.name
             
-    def get_queue(self, subject):
-        if subject is None:
-            subject = self.last_queue
-        if subject in self.queues:
-            self.update_queue(self.queues[subject])
-            return self.queues[subject]
         return None
+
+    def move(self, name, user_id, pos):
+        queue = self._get_queue(name)
+        if queue is None:
+            return None, None
+        elif user_id not in queue.positions:
+            status.handler.error('Тебя нет в этой очереди. Используй /sign_up')
+        elif user_id in user_model.users:
+            result = queue.add_to_pos(user_id, pos)
+            if result is None:
+                self._update_queue(queue)
+                return queue.name, queue.positions[user_id]
+        return None, None
+
+    def clear_queue(self, name):
+        queue = self._get_queue(name)
+        if queue is not None:
+            queue.positions.clear()
+            self._update_queue(queue)
+            
+    def get_queue(self, name):
+        queue = self._get_queue(name)
+        self._update_last_queue(queue.name)
+        return str(queue)
        
     def get_all_queues(self):
         return '\n'.join([f'{i + 1}. {name}' for i, name in enumerate(self.queues.keys())])
+        
+    def _get_queue(self, name):
+        if name is None:
+            name = self.last_queue
+        if name in self.queues:
+            return self.queues[name]
+        else:
+            status.handler.error('Очередь для заданного предмета не найдена :(')
 
 
 queue_model = QueueModel()

--- a/queues/models.py
+++ b/queues/models.py
@@ -41,7 +41,7 @@ class QueueModel:
     def __init__(self):
         self.cursor = None
         self.conn = None
-        self.last_queue = None
+        self.last_queue_name = None
         self.queues = dict()
         self._read_database()
 
@@ -54,14 +54,14 @@ class QueueModel:
                 self.queues[name] = Queue(name=name,
                                           positions=pickle.loads(queue_str))
                 if is_last == 1:
-                    self.last_queue = name
+                    self.last_queue_name = name
                     
     @connector
     def _update_last_queue(self, name):
-        if self.last_queue == name:
+        if self.last_queue_name == name:
             return
-        old_last_queue = self.last_queue
-        self.last_queue = name
+        old_last_queue = self.last_queue_name
+        self.last_queue_name = name
         self.cursor.execute("""UPDATE queues SET is_last=1 WHERE subject=(%s)""",
                             (name,))
         if old_last_queue is not None:
@@ -85,8 +85,8 @@ class QueueModel:
             return None
         self.queues.pop(name)
         self.cursor.execute("""DELETE FROM queues WHERE subject=(%s)""", (name,))
-        if self.last_queue == name:
-            self.last_queue = None
+        if self.last_queue_name == name:
+            self.last_queue_name = None
 
     @connector
     def _update_queue(self, queue: Queue):
@@ -149,7 +149,7 @@ class QueueModel:
         
     def _get_queue(self, name):
         if name is None:
-            name = self.last_queue
+            name = self.last_queue_name
         if name in self.queues:
             return self.queues[name]
         else:

--- a/queues/status.py
+++ b/queues/status.py
@@ -1,0 +1,32 @@
+import enum
+from base.bot import bot
+
+
+# Frequent error messages
+VALUE_ERROR = 'Wrong format'
+
+
+class StatusHandler:
+    def __init__(self):
+        self.reset()
+        
+    def error(self, error_msg):
+        self.error_msg = error_msg
+        self.ok = False
+        
+    def reset(self):
+        self.ok = True
+        self.error_msg = None
+        self.success_msg = None
+        
+    def send_and_reset(self, chat_id, success_args=[], error_args=[]):
+        if self.ok:
+            message = self.success_msg.format(*success_args)
+        else:
+            message = self.error_msg.format(*error_args)
+            
+        bot.send_message(chat_id, message)
+        self.reset()
+        
+        
+handler = StatusHandler()

--- a/queues/status.py
+++ b/queues/status.py
@@ -1,6 +1,4 @@
-import enum
 from base.bot import bot
-
 
 # Frequent error messages
 VALUE_ERROR = 'Wrong format'
@@ -9,24 +7,24 @@ VALUE_ERROR = 'Wrong format'
 class StatusHandler:
     def __init__(self):
         self.reset()
-        
+
     def error(self, error_msg):
         self.error_msg = error_msg
         self.ok = False
-        
+
     def reset(self):
         self.ok = True
         self.error_msg = None
         self.success_msg = None
-        
-    def send_and_reset(self, chat_id, success_args=[], error_args=[]):
+
+    def send_and_reset(self, chat_id, success_args=tuple(), error_args=tuple()):
         if self.ok:
             message = self.success_msg.format(*success_args)
         else:
             message = self.error_msg.format(*error_args)
-            
+
         bot.send_message(chat_id, message)
         self.reset()
-        
-        
+
+
 handler = StatusHandler()

--- a/queues/views.py
+++ b/queues/views.py
@@ -11,7 +11,7 @@ def sign_up(message):
     res_name, res_pos = None, None
     user_id = message.from_user.id
     status.handler.success_msg = '{} {} теперь в очереди на {}, позиция: {}'
-    
+
     try:
         command, name, pos = _parse_args(message.text, with_pos=True)
         if command.startswith('/sign_up'):
@@ -20,15 +20,15 @@ def sign_up(message):
             res_name, res_pos = queue_model.move(name, user_id, pos)
     except ValueError:
         status.handler.error(status.VALUE_ERROR)
-        
+
     status.handler.send_and_reset(message.chat.id, success_args=[
-            user_model.users[user_id].first_name,
-            user_model.users[user_id].last_name,
-            res_name,
-            res_pos,
+        user_model.users[user_id].first_name,
+        user_model.users[user_id].last_name,
+        res_name,
+        res_pos,
     ])
-        
-        
+
+
 @bot.message_handler(commands=['cancel'])
 @exception_handler
 def cancel_sign_up(message):
@@ -40,11 +40,11 @@ def cancel_sign_up(message):
         res_name = queue_model.cancel_sign_up(name, user_id)
     except ValueError:
         status.handler.error(status.VALUE_ERROR)
-        
+
     status.handler.send_and_reset(message.chat.id, success_args=[
-            user_model.users[user_id].first_name,
-            user_model.users[user_id].last_name,
-            res_name,
+        user_model.users[user_id].first_name,
+        user_model.users[user_id].last_name,
+        res_name,
     ])
 
 
@@ -58,15 +58,16 @@ def send_queue(message):
         queue_str = queue_model.get_queue(name)
     except ValueError:
         status.handler.error(status.VALUE_ERROR)
-        
+
     status.handler.send_and_reset(message.chat.id, success_args=[queue_str])
-        
+
+
 @bot.message_handler(commands=['queues'])
 @exception_handler
 def send_queues(message):
     bot.send_message(message.chat.id,
                      ('Как же я люблю очереди, вот они слева направо:\n'
-                         + queue_model.get_all_queues()))
+                      + queue_model.get_all_queues()))
 
 
 @bot.message_handler(commands=['add_queue'])
@@ -84,7 +85,7 @@ def add_queue(message):
             queue_model.add_queue(Queue(name.lower().capitalize()))
     except ValueError:
         status.handler.error(status.VALUE_ERROR)
-        
+
     status.handler.send_and_reset(message.chat.id)
 
 
@@ -98,10 +99,10 @@ def clear_queue(message):
         queue_model.clear_queue(name)
     except ValueError:
         status.handler.error(status.VALUE_ERROR)
-        
+
     status.handler.send_and_reset(message.chat.id)
-    
-    
+
+
 @bot.message_handler(commands=['remove_queue'])
 @exception_handler
 @admin_only
@@ -112,20 +113,21 @@ def remove_queue(message):
         queue_model.remove_queue(name)
     except ValueError:
         status.handler.error(status.VALUE_ERROR)
-        
+
     status.handler.send_and_reset(message.chat.id)
 
-        
+
 def _can_convert_to_int(s):
     try:
         int(s)
         return True
     except ValueError:
         return False
-    
+
+
 def _parse_args(text, with_pos=False):
     args = text.split(maxsplit=(2 if with_pos else 1))
-    
+
     command = args[0]
     name, pos = None, None
     for arg in args[1:]:
@@ -135,7 +137,7 @@ def _parse_args(text, with_pos=False):
             pos = int(arg)
         else:
             raise ValueError()
-            
+
     if with_pos:
         return command, name, pos
     else:

--- a/queues/views.py
+++ b/queues/views.py
@@ -117,13 +117,11 @@ def remove_queue(message):
 
         
 def _can_convert_to_int(s):
-    answer = False
     try:
         int(s)
-        answer = True
+        return True
     except ValueError:
-        pass
-    return answer
+        return False
     
 def _parse_args(text, with_pos=False):
     args = text.split(maxsplit=(2 if with_pos else 1))

--- a/queues/views.py
+++ b/queues/views.py
@@ -1,5 +1,6 @@
 from base.bot import bot
 from base.decorators.common import exception_handler, admin_only
+from queues import status
 from queues.models import queue_model, Queue
 from users.models import user_model
 
@@ -7,91 +8,113 @@ from users.models import user_model
 @bot.message_handler(commands=['sign_up', 'move'])
 @exception_handler
 def sign_up(message):
+    res_name, res_pos = None, None
+    user_id = message.from_user.id
+    status.handler.success_msg = '{} {} теперь в очереди на {}, позиция: {}'
+    
     try:
-        command, subject, pos = _parse_args(message.text, with_pos=True)
-        user_id = message.from_user.id
-        if command == '/sign_up':
-            result = queue_model.sign_up(subject, user_id, pos)
+        command, name, pos = _parse_args(message.text, with_pos=True)
+        if command.startswith('/sign_up'):
+            res_name, res_pos = queue_model.sign_up(name, user_id, pos)
         else:
-            result = queue_model.move(subject, user_id, pos)
-        if result is None:
-            subject = subject or queue_model.last_queue
-            resulting_pos = queue_model.queues[subject].positions[user_id]
-            bot.send_message(message.chat.id, f'{user_model.users[user_id].first_name} '
-                                              f'{user_model.users[user_id].last_name} теперь в очереди '
-                                              f'на {subject}, позиция: {resulting_pos}')
-        else:
-            bot.send_message(message.chat.id, result)
+            res_name, res_pos = queue_model.move(name, user_id, pos)
     except ValueError:
-        bot.send_message(message.chat.id, 'wrong format')
+        status.handler.error(status.VALUE_ERROR)
+        
+    status.handler.send_and_reset(message.chat.id, success_args=[
+            user_model.users[user_id].first_name,
+            user_model.users[user_id].last_name,
+            res_name,
+            res_pos,
+    ])
         
         
 @bot.message_handler(commands=['cancel'])
 @exception_handler
 def cancel_sign_up(message):
+    res_name = None
+    user_id = message.from_user.id
+    status.handler.success_msg = '{} {} теперь не в очереди на {}'
     try:
-        command, subject = _parse_args(message.text)
-        user_id = message.from_user.id
-        result = queue_model.cancel_sign_up(subject, user_id)
-        if result is None:
-            bot.send_message(message.chat.id, f'{user_model.users[user_id].first_name} '
-                                              f'{user_model.users[user_id].last_name} теперь не в очереди '
-                                              f'на {subject}')
-        else:
-            bot.send_message(message.chat.id, result)
+        command, name = _parse_args(message.text)
+        res_name = queue_model.cancel_sign_up(name, user_id)
     except ValueError:
-        bot.send_message(message.chat.id, 'wrong format')
+        status.handler.error(status.VALUE_ERROR)
+        
+    status.handler.send_and_reset(message.chat.id, success_args=[
+            user_model.users[user_id].first_name,
+            user_model.users[user_id].last_name,
+            res_name,
+    ])
 
 
 @bot.message_handler(commands=['queue'])
 @exception_handler
 def send_queue(message):
+    queue_str = None
+    status.handler.success_msg = '{}'
     try:
-        command, subject = _parse_args(message.text)
-        queue_str = queue_model.get_queue(subject)
-        if queue_str is not None:
-            bot.send_message(message.chat.id, queue_str)
-        else:
-            bot.send_message(message.chat.id, 'Очередь для заданного предмета не найдена :(')
+        command, name = _parse_args(message.text)
+        queue_str = queue_model.get_queue(name)
     except ValueError:
-        bot.send_message(message.chat.id, 'wrong format')
+        status.handler.error(status.VALUE_ERROR)
+        
+    status.handler.send_and_reset(message.chat.id, success_args=[queue_str])
         
 @bot.message_handler(commands=['queues'])
 @exception_handler
-def send_queue(message):
+def send_queues(message):
     bot.send_message(message.chat.id,
-                     'Вот они слева направо:\n' + queue_model.get_all_queues())
+                     ('Как же я люблю очереди, вот они слева направо:\n'
+                         + queue_model.get_all_queues()))
 
 
 @bot.message_handler(commands=['add_queue'])
 @exception_handler
 @admin_only
 def add_queue(message):
+    status.handler.success_msg = 'Очередь создана'
     try:
-        command, subject = message.text.split(maxsplit=1)
-        if _can_convert_to_int(subject):
-            bot.send_message(message.chat.id, 'Не умею называть очереди числами :(')
-        elif ' ' in subject:
-            bot.send_message(message.chat.id, 'Ограничьте свою фантазию одним словом')
+        command, name = message.text.split(maxsplit=1)
+        if _can_convert_to_int(name):
+            status.handler.error('Не умею называть очереди числами :(')
+        elif ' ' in name:
+            status.handler.error('Ограничьте свою фантазию одним словом')
         else:
-            queue_model.add_queue(Queue(subject))
-            bot.send_message(message.chat.id, 'Очередь создана')
+            queue_model.add_queue(Queue(name.lower().capitalize()))
     except ValueError:
-        bot.send_message(message.chat.id, 'wrong format')
+        status.handler.error(status.VALUE_ERROR)
+        
+    status.handler.send_and_reset(message.chat.id)
 
 
 @bot.message_handler(commands=['clear_queue'])
 @exception_handler
 @admin_only
 def clear_queue(message):
+    status.handler.success_msg = 'Очередь очищена'
     try:
-        command, subject = _parse_args(text.message)
-        if queue_model.clear_queue(subject):
-            bot.send_message(message.chat.id, 'Очередь очищена')
-        else:
-            bot.send_message(message.chat.id, 'Что-то не вышло(')
+        command, name = _parse_args(message.text)
+        queue_model.clear_queue(name)
     except ValueError:
-        bot.send_message(message.chat.id, 'wrong format')
+        status.handler.error(status.VALUE_ERROR)
+        
+    status.handler.send_and_reset(message.chat.id)
+    
+    
+@bot.message_handler(commands=['remove_queue'])
+@exception_handler
+@admin_only
+def remove_queue(message):
+    status.handler.success_msg = 'Очередь удалена'
+    try:
+        command, name = _parse_args(message.text)
+        queue_model.remove_queue(name)
+    except ValueError:
+        status.handler.error(status.VALUE_ERROR)
+        
+    status.handler.send_and_reset(message.chat.id)
+
         
 def _can_convert_to_int(s):
     answer = False
@@ -104,18 +127,18 @@ def _can_convert_to_int(s):
     
 def _parse_args(text, with_pos=False):
     args = text.split(maxsplit=(2 if with_pos else 1))
+    
     command = args[0]
-    subject = None
-    pos = None
+    name, pos = None, None
     for arg in args[1:]:
         if not _can_convert_to_int(arg):
-            subject = arg
+            name = arg.lower().capitalize()
         elif with_pos:
             pos = int(arg)
         else:
             raise ValueError()
             
     if with_pos:
-        return command, subject, pos
+        return command, name, pos
     else:
-        return command, subject
+        return command, name


### PR DESCRIPTION
Теперь можно не писать в командах аргумент "имя очереди": в этом случае будет использоваться последняя очередь, с которой кто-либо взаимодействовал.

Например:
```
/queue бжч
----> Очередь на бжч пустая.
/sign_up
----> Ты теперь в очереди на бжч.
/sign_up мча
----> Ты теперь в очереди на мча.
/move 5
----> Ты теперь в очереди на мча на позиции 5.
```

Если имя очереди все же указывается, то теперь не важен порядок аргументов, т. е. `move бжч 2` и `move 2 бжч` делают одно и то же.

Плюс добавилась возможность выводить все очереди командой `/queues`.